### PR TITLE
Option 6 - Using viewWillLayoutSubviews

### DIFF
--- a/DynamicWidthCollectionViewCells.xcodeproj/project.pbxproj
+++ b/DynamicWidthCollectionViewCells.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		130036C01C67561800EC0794 /* FullWidthCellsFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130036BF1C67561800EC0794 /* FullWidthCellsFlowLayout.swift */; };
 		134CAB021C83075800CA6CA4 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134CAB001C83075800CA6CA4 /* CollectionViewCell.swift */; };
 		134CAB031C83075800CA6CA4 /* CollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 134CAB011C83075800CA6CA4 /* CollectionViewCell.xib */; };
+		70FC932D1C83767200A8BD34 /* OptionSixViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70FC932C1C83767200A8BD34 /* OptionSixViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		130036BF1C67561800EC0794 /* FullWidthCellsFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullWidthCellsFlowLayout.swift; sourceTree = "<group>"; };
 		134CAB001C83075800CA6CA4 /* CollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewCell.swift; sourceTree = "<group>"; };
 		134CAB011C83075800CA6CA4 /* CollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CollectionViewCell.xib; sourceTree = "<group>"; };
+		70FC932C1C83767200A8BD34 /* OptionSixViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionSixViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,9 +62,9 @@
 		130036AC1C67538B00EC0794 /* DynamicWidthCollectionViewCells */ = {
 			isa = PBXGroup;
 			children = (
+				70FC932E1C8378B400A8BD34 /* Option 5 */,
+				70FC932F1C8378C000A8BD34 /* Option 6 */,
 				130036AD1C67538B00EC0794 /* AppDelegate.swift */,
-				130036AF1C67538B00EC0794 /* OptionFiveViewController.swift */,
-				130036BF1C67561800EC0794 /* FullWidthCellsFlowLayout.swift */,
 				134CAB001C83075800CA6CA4 /* CollectionViewCell.swift */,
 				134CAB011C83075800CA6CA4 /* CollectionViewCell.xib */,
 				130036B11C67538B00EC0794 /* Main.storyboard */,
@@ -71,6 +73,23 @@
 				130036B91C67538B00EC0794 /* Info.plist */,
 			);
 			path = DynamicWidthCollectionViewCells;
+			sourceTree = "<group>";
+		};
+		70FC932E1C8378B400A8BD34 /* Option 5 */ = {
+			isa = PBXGroup;
+			children = (
+				130036AF1C67538B00EC0794 /* OptionFiveViewController.swift */,
+				130036BF1C67561800EC0794 /* FullWidthCellsFlowLayout.swift */,
+			);
+			name = "Option 5";
+			sourceTree = "<group>";
+		};
+		70FC932F1C8378C000A8BD34 /* Option 6 */ = {
+			isa = PBXGroup;
+			children = (
+				70FC932C1C83767200A8BD34 /* OptionSixViewController.swift */,
+			);
+			name = "Option 6";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -145,6 +164,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70FC932D1C83767200A8BD34 /* OptionSixViewController.swift in Sources */,
 				134CAB021C83075800CA6CA4 /* CollectionViewCell.swift in Sources */,
 				130036B01C67538B00EC0794 /* OptionFiveViewController.swift in Sources */,
 				130036C01C67561800EC0794 /* FullWidthCellsFlowLayout.swift in Sources */,

--- a/DynamicWidthCollectionViewCells/Base.lproj/Main.storyboard
+++ b/DynamicWidthCollectionViewCells/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O8k-LB-Q9U">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="O8k-LB-Q9U">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--Options-->
@@ -16,15 +16,15 @@
                         <sections>
                             <tableViewSection id="R53-0z-FVF">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="optionCell" textLabel="g8x-EK-wyM" style="IBUITableViewCellStyleDefault" id="QRR-Ny-oUU">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="optionCell" textLabel="g8x-EK-wyM" style="IBUITableViewCellStyleDefault" id="QRR-Ny-oUU">
                                         <rect key="frame" x="0.0" y="64" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QRR-Ny-oUU" id="dHA-sh-0qg">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="567" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Option 5: Flow Layout Subclass - modifying item size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="g8x-EK-wyM">
-                                                    <rect key="frame" x="15" y="0.0" width="570" height="43"/>
+                                                    <rect key="frame" x="15" y="0.0" width="550" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -34,6 +34,26 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="BYZ-38-t0r" kind="show" id="rAY-gw-g4O"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="optionCell" textLabel="1uR-n8-GfO" style="IBUITableViewCellStyleDefault" id="FMN-Hb-bwI">
+                                        <rect key="frame" x="0.0" y="108" width="600" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FMN-Hb-bwI" id="yge-c9-JUC">
+                                            <rect key="frame" x="0.0" y="0.0" width="567" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Option 6: Use &quot;viewWillLayoutSubviews&quot;" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1uR-n8-GfO">
+                                                    <rect key="frame" x="15" y="0.0" width="550" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="X3C-uk-gz7" kind="show" id="RjJ-22-Vbl"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -108,6 +128,50 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gys-Qg-Nph" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-297" y="377"/>
+        </scene>
+        <!--Option 6-->
+        <scene sceneID="EC6-L9-7g6">
+            <objects>
+                <viewController id="X3C-uk-gz7" customClass="OptionSixViewController" customModule="DynamicWidthCollectionViewCells" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="WJV-9V-iKc"/>
+                        <viewControllerLayoutGuide type="bottom" id="g5g-To-rqi"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Cdc-py-wFE">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Bnd-1A-1sT">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="u5w-h1-xL2">
+                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                                <connections>
+                                    <outlet property="dataSource" destination="X3C-uk-gz7" id="NQ6-Mw-wPV"/>
+                                    <outlet property="delegate" destination="X3C-uk-gz7" id="OHY-wp-rMF"/>
+                                </connections>
+                            </collectionView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="g5g-To-rqi" firstAttribute="top" secondItem="Bnd-1A-1sT" secondAttribute="bottom" id="4Mi-ee-jZw"/>
+                            <constraint firstItem="Bnd-1A-1sT" firstAttribute="leading" secondItem="Cdc-py-wFE" secondAttribute="leading" id="AOp-1m-wr9"/>
+                            <constraint firstItem="Bnd-1A-1sT" firstAttribute="top" secondItem="Cdc-py-wFE" secondAttribute="top" id="oFo-fR-PUi"/>
+                            <constraint firstAttribute="trailing" secondItem="Bnd-1A-1sT" secondAttribute="trailing" id="wO7-Yx-HKh"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="Option 6" id="kBp-Ed-hzx"/>
+                    <connections>
+                        <outlet property="collectionView" destination="Bnd-1A-1sT" id="nhl-9v-ZcS"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="y8c-Ec-JTs" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1222" y="716"/>
         </scene>
     </scenes>
 </document>

--- a/DynamicWidthCollectionViewCells/OptionSixViewController.swift
+++ b/DynamicWidthCollectionViewCells/OptionSixViewController.swift
@@ -55,6 +55,9 @@ extension OptionSixViewController: UICollectionViewDataSource {
 
 extension OptionSixViewController: UICollectionViewDelegateFlowLayout {
   func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
-    return CGSizeMake(collectionView.frame.width, CGFloat(68))
+    let flowLayout = collectionViewLayout as! UICollectionViewFlowLayout, insets = flowLayout.sectionInset
+    let itemWidth = collectionView.frame.width - insets.left - insets.right, itemHeight = CGFloat(68)
+    
+    return CGSizeMake(itemWidth, itemHeight)
   }
 }

--- a/DynamicWidthCollectionViewCells/OptionSixViewController.swift
+++ b/DynamicWidthCollectionViewCells/OptionSixViewController.swift
@@ -1,0 +1,60 @@
+//
+//  OptionSixViewController.swift
+//  DynamicWidthCollectionViewCells
+//
+//  Created by Almas Daumov on 2/28/16.
+//  Copyright © 2016 matrixprojects.net. All rights reserved.
+//
+
+import UIKit
+
+class OptionSixViewController: UIViewController {
+  @IBOutlet var collectionView: UICollectionView!
+  
+  struct Item {
+    let name : String
+  }
+  
+  var items = [Item]()
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    collectionView.registerNib(CollectionViewCell.nib, forCellWithReuseIdentifier: "cell")
+    
+    updateItems()
+    collectionView.reloadData()
+  }
+  
+  // MARK: Private
+  
+  private func updateItems() {
+    items.removeAll()
+    for i in 0...25 {
+      items.append(Item(name: "Cell \(i)"))
+    }
+  }
+  
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    collectionView.collectionViewLayout.invalidateLayout()
+  }
+}
+
+extension OptionSixViewController: UICollectionViewDataSource {
+  func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return items.count
+  }
+  
+  func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+    let cell = collectionView.dequeueReusableCellWithReuseIdentifier("cell", forIndexPath: indexPath) as! CollectionViewCell
+    cell.textLabel.text = items[indexPath.item].name
+    return cell
+  }
+}
+
+extension OptionSixViewController: UICollectionViewDelegateFlowLayout {
+  func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
+    return CGSizeMake(collectionView.frame.width, CGFloat(68))
+  }
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Based on the write up in [this blog post](http://www.matrixprojects.net/p/uicoll
 - A subclass of `UICollectionViewFlowLayout` is used
 - The subclass modifies `itemSize`'s `width` property on bounds change
 
+### Option 6: Use "viewWillLayoutSubviews"
+
+- Invalidates layout in "viewWillLayoutSubviews"
+- Calculates new size in "collectionView:collectionViewLayout:sizeForItemAtIndex"
+
 # Contributions
 
 Contributions are welcome! 


### PR DESCRIPTION
This option is similar to [Option 3](http://www.matrixprojects.net/p/uicollectionviewcell-dynamic-width/#option-3-reacting-to-rotations), but it uses "viewWillLayoutSubviews" instead of "viewWillTransitionToSize", and therefore there is no need to create an extra property to store the new view size.
